### PR TITLE
Adiciona o formato AGRiS.

### DIFF
--- a/config/crosswalks/oai/metadataFormats/agris_xml_example.xml
+++ b/config/crosswalks/oai/metadataFormats/agris_xml_example.xml
@@ -1,0 +1,61 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2023-08-28T13:42:24Z</responseDate>
+<request verb="ListRecords" metadataPrefix="oai_dc_agris">http://www.scielo.cl/oai/scielo-oai.php</request>
+<ListRecords>
+<record>
+    <header>
+        <identifier>oai:agris.scielo:XS1998000701</identifier>
+        <datestamp>1999-06-15</datestamp>
+        <setSpec>0034-9887</setSpec>
+    </header>
+    <metadata>
+        <ags:resources xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:ags="http://purl.org/agmes/1.1/" xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
+            xmlns:dcterms="http://purl.org/dc/terms/">
+            <ags:resource ags:ARN="XS1998000701">
+                <dc:title xml:lang="es"><![CDATA[Influencia de factores de riesgo y terapia farmacológica en la mortalidad de hipertensos esenciales]]></dc:title>
+                <dc:creator>
+                    <ags:creatorPersonal>Román A, Oscar(Universidad de Chile)</ags:creatorPersonal>
+                    <ags:creatorPersonal>Cuevas S, Gerardo(Hospital San Borja Arriarán)</ags:creatorPersonal>
+                    <ags:creatorPersonal>Bunout B, Daniel</ags:creatorPersonal>
+                </dc:creator>
+                <dc:publisher>
+                    <ags:publisherName>Sociedad Médica de Santiago</ags:publisherName>
+                </dc:publisher>
+                <dc:date>
+                    <dcterms:dateIssued>1998</dcterms:dateIssued>
+                </dc:date>
+                <dc:subject>Hypertension</dc:subject>
+                <dc:subject>Antihypertensive agents</dc:subject>
+                <dc:subject>Adrenergic beta-antagonists</dc:subject>
+                <dc:subject>Calcium channel blockers</dc:subject>
+                <dc:description>
+                    <dcterms:abstract xml:lang="en"><![CDATA[Background: The VJN consensus stated that although new antihypertensive agents, such as angiotensin converting enzyme inhibitors and calcium channel blockers, are considered safer drugs, there is no firm evidence from large controlled trials that these drugs are associated with a lower cardiovascular mortality. Aim: To study the association between cardiovascular risk factors, blood pressure levels, pharmacological treatment and mortality in a group of hypertensive patients followed at an hypertension outpatient clinic. Patients and methods: Patients with essential hypertension were treated with different antihypertensive medications, according to physicians criteria, and controlled until death or loss from follow up. Causes of death were obtained from hospital records and death certificates. Survival was analyzed using life tables, comparisons between groups of patients were done using chi square or a CoxÕs proportional hazards model. Results: Three hundred thirty nine hypertensive patients aged 33 to 80 years old were followed for a mean period of 9.8 ± 4.9 years. Eighty six were treated with beta blockers, 64 with diuretics, 133 with calcium antagonists and 56 with ACE inhibitors. Blood pressure dropped similarly with all medications. During follow up, 79 patients died. Life table analysis showed that patients with a history of angina, diabetes or myocardial infarction had higher mortality rates. Similarly, patients treated with beta blockers and diuretics had higher mortality than patients treated with calcium antagonists or angiotensin converting enzyme inhibitors. The proportional hazards model showed that the effect of treatment modality persisted after correction for the other risk factors for mortality. Conclusions: In this series of hypertensive patients, those treated with beta blockers or diuretics had higher mortality rates than those receiving calcium channel antagonists or angiotensin converting enzyme inhibitors.]]></dcterms:abstract>
+                </dc:description>
+                <dc:identifier scheme="dcterms:URI">
+                    &lt;![CDATA[http://www.scielo.cl/scielo.php?script=sci_arttext&amp;pid=S0034-98871998000700001&amp;lng=en&amp;nrm=iso&amp;tlng=en]]&gt;</dc:identifier>
+                <dc:identifier scheme="ags:DOI" />
+                <dc:type>journal article</dc:type>
+                <dc:format>
+                    <dcterms:medium>text/xml</dcterms:medium>
+                </dc:format>
+                <dc:language scheme="ags:ISO639-1">es</dc:language>
+                <agls:availability>
+                    <ags:availabilityLocation>SCIELO</ags:availabilityLocation>
+                    <ags:availabilityNumber />
+                </agls:availability>
+                <ags:citation>
+                    <ags:citationTitle>Revista médica de Chile</ags:citationTitle>
+                    <ags:citationIdentifier scheme="ags:ISSN">0034-9887</ags:citationIdentifier>
+                    <ags:citationNumber>vol.126 num.7</ags:citationNumber>
+                    <ags:citationChronology>1998/07</ags:citationChronology>
+                </ags:citation>
+            </ags:resource>
+        </ags:resources>
+    </metadata>
+</record>

--- a/config/crosswalks/oai/metadataFormats/oai_dc_agris.xsl
+++ b/config/crosswalks/oai/metadataFormats/oai_dc_agris.xsl
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+        Developed by DSpace @ Lyncode <dspace@lyncode.com>
+
+        > http://www.openarchives.org/OAI/2.0/oai_dc.xsd
+
+ -->
+
+
+<xsl:stylesheet
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:doc="http://www.lyncode.com/xoai"
+        xmlns:ags="http://purl.org/agmes/1.1/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        version="1.0">
+        <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
+
+        <xsl:template match="/">
+                <ags:resource xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                        xmlns:ags="http://purl.org/agmes/1.1/"
+                        xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
+                        xmlns:dcterms="http://purl.org/dc/terms/">
+                        <!-- dc.title -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
+                                <dc:title>
+                                        <xsl:value-of select="." />
+                                </dc:title>
+                        </xsl:for-each>
+                        <!-- dc.title.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:title>
+                                        <xsl:value-of select="." />
+                                </dc:title>
+                        </xsl:for-each>
+                        <!-- dc.creator -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
+                                <dc:creator>
+                                        <ags:creatorPersonal><xsl:value-of select="." /></ags:creatorPersonal>
+                                </dc:creator>
+                        </xsl:for-each>
+                        <!-- dc.contributor.author -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+                                <dc:creator>
+                                        <xsl:value-of select="." />
+                                </dc:creator>
+                        </xsl:for-each>
+
+
+                        <!-- dc.contributor.author -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:field[@name='value']">
+                                <dc:creator>
+                                        <xsl:value-of select="." />
+                                </dc:creator>
+                        </xsl:for-each>
+
+                        <!-- dc.contributor.* (!author) -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author' and
+                                                                                                                                @name!='authorID' and
+                                                                                                                                @name!='authorLattes' and
+                                                                                                                                @name!='advisor1ID' and
+                                                                                                                                @name!='advisor1Lattes' and
+                                                                                                                                @name!='advisor2ID' and
+                                                                                                                                @name!='advisor2Lattes' and
+                                                                                                                                @name!='advisor-co1ID' and
+                                                                                                                                @name!='advisor-co1Lattes' and
+                                                                                                                                @name!='advisor-co2ID' and
+                                                                                                                                @name!='advisor-co2Lattes' and
+                                                                                                                                @name!='referee1ID' and
+                                                                                                                                @name!='referee1Lattes' and
+                                                                                                                                @name!='referee2ID' and
+                                                                                                                                @name!='referee2Lattes' and
+                                                                                                                                @name!='referee3ID' and
+                                                                                                                                @name!='referee3Lattes' and
+                                                                                                                                @name!='referee4ID' and
+                                                                                                                                @name!='referee4Lattes' and
+                                                                                                                                @name!='referee5ID' and
+                                                                                                                                @name!='referee5Lattes']/doc:element/doc:field[@name='value']">
+                                <dc:contributor>
+                                        <xsl:value-of select="." />
+                                </dc:contributor>
+                        </xsl:for-each>
+
+                        <!-- dc.contributor -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author' and
+                                                                                                                                @name!='authorID' and
+                                                                                                                                @name!='authorLattes' and
+                                                                                                                                @name!='advisor1ID' and
+                                                                                                                                @name!='advisor1Lattes' and
+                                                                                                                                @name!='advisor2ID' and
+                                                                                                                                @name!='advisor2Lattes' and
+                                                                                                                                @name!='advisor-co1ID' and
+                                                                                                                                @name!='advisor-co1Lattes' and
+                                                                                                                                @name!='advisor-co2ID' and
+                                                                                                                                @name!='advisor-co2Lattes' and
+                                                                                                                                @name!='referee1ID' and
+                                                                                                                                @name!='referee1Lattes' and
+                                                                                                                                @name!='referee2ID' and
+                                                                                                                                @name!='referee2Lattes' and
+                                                                                                                                @name!='referee3ID' and
+                                                                                                                                @name!='referee3Lattes' and
+                                                                                                                                @name!='referee4ID' and
+                                                                                                                                @name!='referee4Lattes' and
+                                                                                                                                @name!='referee5ID' and
+                                                                                                                                @name!='referee5Lattes']/doc:field[@name='value']">
+                                <dc:contributor>
+                                        <xsl:value-of select="." />
+                                </dc:contributor>
+                        </xsl:for-each>
+
+                        <!-- dc.subject -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
+                                <dc:subject>
+                                        <xsl:value-of select="." />
+                                </dc:subject>
+                        </xsl:for-each>
+                        <!-- dc.subject.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:subject>
+                                        <xsl:value-of select="." />
+                                </dc:subject>
+                        </xsl:for-each>
+                        <!-- dc.description -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element/doc:field[@name='value']">
+                                <dc:description>
+                                        <xsl:value-of select="." />
+                                </dc:description>
+                        </xsl:for-each>
+                        <!-- dc.description.* (not provenance)-->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name!='provenance']/doc:element/doc:field[@name='value']">
+                                <dc:description>
+                                        <dcterms:abstract><xsl:value-of select="." /></dcterms:abstract>
+                                </dc:description>
+                        </xsl:for-each>
+                        <!-- dc.date -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:field[@name='value']">
+                                <dc:date>
+                                        <dcterms:dateIssued><xsl:value-of select="." /></dcterms:dateIssued>
+                                </dc:date>
+                        </xsl:for-each>
+                        <!-- dc.date.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:date>
+                                        <xsl:value-of select="." />
+                                </dc:date>
+                        </xsl:for-each>
+                        <!-- dc.type -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value']">
+                                <dc:type>
+                                        <xsl:value-of select="." />
+                                </dc:type>
+                        </xsl:for-each>
+                        <!-- dc.type.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:type>
+                                        <xsl:value-of select="." />
+                                </dc:type>
+                        </xsl:for-each>
+                        <!-- dc.identifier -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:field[@name='value']">
+                                <dc:identifier>
+                                        <dc:identifier scheme="dcterms:URI"><xsl:value-of select="." /></dc:identifier>
+                                </dc:identifier>
+                        </xsl:for-each>
+                        <!-- dc.identifier.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:identifier>
+                                        <xsl:value-of select="." />
+                                </dc:identifier>
+                        </xsl:for-each>
+                        <!-- dc.language -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
+                                <dc:language scheme="ags:ISO639-1">
+                                        <xsl:value-of select="." />
+                                </dc:language>
+                        </xsl:for-each>
+                        <!-- dc.language.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:language>
+                                        <xsl:value-of select="." />
+                                </dc:language>
+                        </xsl:for-each>
+                        <!-- dc.relation -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
+                                <dc:relation>
+                                        <xsl:value-of select="." />
+                                </dc:relation>
+                        </xsl:for-each>
+                        <!-- dc.relation.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:relation>
+                                        <xsl:value-of select="." />
+                                </dc:relation>
+                        </xsl:for-each>
+                        <!-- dc.rights -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']">
+                                <dc:rights>
+                                        <xsl:value-of select="." />
+                                </dc:rights>
+                        </xsl:for-each>
+                        <!-- dc.rights.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:rights>
+                                        <xsl:value-of select="." />
+                                </dc:rights>
+                        </xsl:for-each>
+                        <!-- dc.format -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
+                                <dc:format>
+                                        <dcterms:medium><xsl:value-of select="." /></dcterms:medium>
+                                </dc:format>
+                        </xsl:for-each>
+                        <!-- dc.format.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:format>
+                                        <xsl:value-of select="." />
+                                </dc:format>
+                        </xsl:for-each>
+                        <!-- ? -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
+                                <dc:format>
+                                        <xsl:value-of select="." />
+                                </dc:format>
+                        </xsl:for-each>
+                        <!-- dc.coverage -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+                                <dc:coverage>
+                                        <xsl:value-of select="." />
+                                </dc:coverage>
+                        </xsl:for-each>
+                        <!-- dc.coverage.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:coverage>
+                                        <xsl:value-of select="." />
+                                </dc:coverage>
+                        </xsl:for-each>
+                        <!-- dc.publisher -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
+                                <dc:publisher>
+                                        <xsl:value-of select="." />
+                                </dc:publisher>
+                        </xsl:for-each>
+                        <!-- dc.publisher.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:publisher>
+                                        <ags:publisherName><xsl:value-of select="." /></ags:publisherName>
+                                </dc:publisher>
+                        </xsl:for-each>
+
+                        <!-- dc.source -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:field[@name='value']">
+                                <dc:source>
+                                        <xsl:value-of select="." />
+                                </dc:source>
+                        </xsl:for-each>
+
+                        <!-- dc.source.* -->
+                        <xsl:for-each
+                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:element/doc:field[@name='value']">
+                                <dc:source>
+                                        <xsl:value-of select="." />
+                                </dc:source>
+                        </xsl:for-each>
+
+                        <about>
+                                <provenance>
+                                        <xsl:variable name="harvestDate"
+                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='harvestDate']" />
+                                        <xsl:variable name="recordStatus"
+                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='altered']" />
+                                        <xsl:variable name="repositoryFullName"
+                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']" />
+                                        <xsl:variable name="repoNameLength"
+                                                select="string-length(tokenize(//*[contains(text(),'reponame')], ':')[2])" />
+                                        <xsl:variable name="openDoarId"
+                                                select="tokenize(doc:metadata/doc:element[@name='repository']/doc:field[@name='repositoryID'], ':')[2]" />
+                                        <originDescription altered="{$recordStatus}"
+                                                harvestDate="{$harvestDate}">
+                                                <baseURL>
+                                                        <xsl:value-of
+                                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='baseURL']" />
+                                                </baseURL>
+                                                <identifier>
+                                                        <xsl:value-of
+                                                                select="doc:metadata/doc:element[@name='others']/doc:field[@name='identifier']" />
+                                                </identifier>
+                                                <datestamp>
+                                                        <xsl:value-of
+                                                                select="doc:metadata/doc:element[@name='others']/doc:field[@name='lastModifyDate']" />
+                                                </datestamp>
+                                                <metadataNamespace>
+                                                        <xsl:text>http://www.openarchives.org/OAI/2.0/oai_dc/</xsl:text>
+                                                </metadataNamespace>
+                                                <xsl:choose>
+                                                        <xsl:when test="matches($openDoarId,'\d+')">
+                                                                <repositoryID>
+                                                                        <xsl:value-of
+                                                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='repositoryID']" />
+                                                                </repositoryID>
+                                                        </xsl:when>
+                                                        <xsl:otherwise>
+                                                                <repositoryID></repositoryID>
+                                                        </xsl:otherwise>
+                                                </xsl:choose>
+                                                <xsl:choose>
+                                                        <xsl:when
+                                                                test="string-length(normalize-space($repositoryFullName))>3">
+                                                                <repositoryName>
+                                                                        <xsl:value-of
+                                                                                select="$repositoryFullName" />
+                                                                </repositoryName>
+                                                        </xsl:when>
+                                                        <xsl:otherwise>
+                                                                <xsl:if test="$repoNameLength!=0">
+                                                                        <repositoryName>
+                                                                                <xsl:value-of
+                                                                                        select="concat(tokenize(//*[contains(text(),'reponame')], ':')[2], concat(' - ', tokenize(//*[contains(text(),'instname')], ':')[2]))" />
+                                                                        </repositoryName>
+                                                                </xsl:if>
+                                                <xsl:if
+                                                                        test="repoNameLength=0">
+                                                                        <repositoryName></repositoryName>
+                                                                </xsl:if>
+                                                        </xsl:otherwise>
+                                                </xsl:choose>
+                                        </originDescription>
+                                </provenance>
+                        </about>
+                </ags:resource>
+        </xsl:template>
+</xsl:stylesheet>

--- a/config/crosswalks/oai/xoai.xml
+++ b/config/crosswalks/oai/xoai.xml
@@ -18,8 +18,10 @@
             <!-- Restrict access to hidden items by default -->
             <!-- Filter ref="defaultFilter" /-->
 
-            <Format ref="oaidc"/>
-            <Format ref="mets"/>
+            <Format ref="oai_dc"/>
+            <Format ref="oai_dc_agris"/>
+            <Format ref="oai_dc_openaire"/>
+            <!-- <Format ref="mets"/>
             <Format ref="xoai"/>
             <Format ref="didl"/>
             <Format ref="dim"/>
@@ -29,10 +31,10 @@
             <Format ref="mods"/>
             <Format ref="qdc"/>
             <Format ref="marc"/>
-            <Format ref="uketd_dc"/>
+            <Format ref="uketd_dc"/> -->
             <!--<Format ref="junii2" />-->
             <Description>
-                This is the default context of the LAReferencia data provider.
+                This is the default context of data provider.
             </Description>
         </Context>
 
@@ -43,21 +45,21 @@
 
             Page 57 - 58
          -->
-        <Context baseurl="driver" name="Driver Context">
+        <!-- <Context baseurl="driver" name="Driver Context"> -->
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <!-- Transformer ref="driverTransformer"/ -->
             <!-- The driver filter -->
-            <Filter ref="driverFilter"/>
+            <!-- <Filter ref="driverFilter"/> -->
             <!-- Just an alias, in fact it returns all items within the driver context -->
-            <Set ref="driverSet"/>
+            <!-- <Set ref="driverSet"/> -->
             <!-- Metadata Formats -->
-            <Format ref="oaidc"/>
-            <Format ref="mets"/>
-            <Format ref="didl"/>
-            <Description>
-                This contexts complies with Driver rules.
-            </Description>
-        </Context>
+            <!-- <Format ref="oaidc"/> -->
+            <!-- <Format ref="mets"/> -->
+            <!-- <Format ref="didl"/> -->
+            <!-- <Description> -->
+                <!-- This contexts complies with Driver rules. -->
+            <!-- </Description> -->
+        <!-- </Context> -->
 
         <!--
             OpenAIRE Guidelines 1.1:
@@ -68,54 +70,54 @@
 
             - Predefined DSpace fields don't allow to set this up with a default.
          -->
-        <Context baseurl="openaire" name="OpenAIRE Context">
+        <!-- <Context baseurl="openaire" name="OpenAIRE Context"> -->
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <!-- Transformer ref="openaireTransformer"/-->
             <!-- OpenAIRE filter -->
-            <Filter ref="openAireFilter"/>
+            <!-- <Filter ref="openAireFilter"/> -->
             <!-- Just an alias, in fact it returns all items within the driver context -->
-            <Set ref="openaireSet"/>
+            <!-- <Set ref="openaireSet"/> -->
             <!-- Metadata Formats -->
-            <Format ref="oaidc"/>
-            <Format ref="mets"/>
-            <Description>
-                This contexts complies with OpenAIRE rules.
-            </Description>
-        </Context>
+            <!-- <Format ref="oaidc"/> -->
+            <!-- <Format ref="mets"/> -->
+            <!-- <Description> -->
+                <!-- This contexts complies with OpenAIRE rules. -->
+            <!-- </Description> -->
+        <!-- </Context> -->
         
-        <Context baseurl="thesis" name="Doctoral and Master Thesis Context">
+        <!-- <Context baseurl="thesis" name="Doctoral and Master Thesis Context"> -->
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <!-- Transformer ref="openaireTransformer"/-->
             
             <!-- OpenAIRE filter -->
-            <Filter ref="thesisFilter"/>
+            <!-- <Filter ref="thesisFilter"/> -->
             
             <!-- Just an alias, in fact it returns all items within the driver context -->
             <!-- Metadata Formats -->
-            <Format ref="oaidc"/>
-            <Format ref="xoai"/>
-            <Format ref="mets"/>
-            <Description>
-                This contexts lists master and doctoral thesis types
-            </Description>
-        </Context>
+            <!-- <Format ref="oaidc"/> -->
+            <!-- <Format ref="xoai"/> -->
+            <!-- <Format ref="mets"/> -->
+            <!-- <Description> -->
+                <!-- This contexts lists master and doctoral thesis types -->
+            <!-- </Description> -->
+        <!-- </Context> -->
         
-        <Context baseurl="lareferencia" name="LAReferencia Accepted Doctypes Context">
+        <!-- <Context baseurl="lareferencia" name="LAReferencia Accepted Doctypes Context"> -->
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <!-- Transformer ref="openaireTransformer"/-->
             
             <!-- OpenAIRE filter -->
-            <Filter ref="lareferenciaFilter"/>
+            <!-- <Filter ref="lareferenciaFilter"/> -->
             
             <!-- Just an alias, in fact it returns all items within the driver context -->
             <!-- Metadata Formats -->
-            <Format ref="oaidc"/>
-            <Format ref="xoai"/>
-            <Format ref="mets"/>
-            <Description>
-               LAReferencia Accepted Doctypes Context
-            </Description>
-        </Context>
+            <!-- <Format ref="oaidc"/> -->
+            <!-- <Format ref="xoai"/> -->
+            <!-- <Format ref="mets"/> -->
+            <!-- <Description> -->
+               <!-- LAReferencia Accepted Doctypes Context -->
+            <!-- </Description> -->
+        <!-- </Context> -->
         
         <!--
             OpenAIRE Guidelines 4.0:
@@ -126,29 +128,42 @@
 
             - Predefined DSpace fields don't allow to set this up with a default.
          -->
-        <Context baseurl="openaire4" name="OpenAIRE 4 Context">
+        <!-- <Context baseurl="openaire4" name="OpenAIRE 4 Context"> -->
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
-            <Transformer ref="openaire4Transformer"/>
+            <!-- <Transformer ref="openaire4Transformer"/> -->
             <!-- OpenAIRE filter -->
-            <Filter ref="defaultFilter"/>
+            <!-- <Filter ref="defaultFilter"/> -->
             <!-- Metadata Formats -->
-            <Format ref="oaiopenaire"/>
-            <Description>
-                This contexts complies with OpenAIRE Guidelines for Literature Repositories v4.0.
-            </Description>
-        </Context>		
+            <!-- <Format ref="oaiopenaire"/> -->
+            <!-- <Description> -->
+                <!-- This contexts complies with OpenAIRE Guidelines for Literature Repositories v4.0. -->
+            <!-- </Description> -->
+        <!-- </Context>		 -->
         
         
     </Contexts>
 
 
     <Formats>
-        <Format id="oaidc">
+        <Format id="oai_dc">
             <Prefix>oai_dc</Prefix>
             <XSLT>metadataFormats/oai_dc.xsl</XSLT>
             <Namespace>http://www.openarchives.org/OAI/2.0/oai_dc/</Namespace>
             <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
         </Format>
+        <Format id="oai_dc_openaire">
+            <Prefix>oai_openaire</Prefix>
+            <XSLT>metadataFormats/oai_openaire.xsl</XSLT>
+            <Namespace>http://namespace.openaire.eu/schema/oaire/</Namespace>
+            <SchemaLocation>https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd</SchemaLocation>
+        </Format>	
+        <Format id="oai_dc_agris">
+            <Prefix>oai_dc_agris</Prefix>
+            <XSLT>metadataFormats/oai_dc_agris.xsl</XSLT>
+            <Namespace>http://www.openarchives.org/OAI/2.0/oai_dc/</Namespace>
+            <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
+        </Format>
+
         <Format id="mets">
             <Prefix>mets</Prefix>
             <XSLT>metadataFormats/mets.xsl</XSLT>
@@ -227,12 +242,7 @@
         <!-- Metadata format based on the OpenAIRE 4.0 guidelines
              https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/use_of_oai_pmh.html
         -->
-        <Format id="oaiopenaire">
-            <Prefix>oai_openaire</Prefix>
-            <XSLT>metadataFormats/oai_openaire.xsl</XSLT>
-            <Namespace>http://namespace.openaire.eu/schema/oaire/</Namespace>
-            <SchemaLocation>https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd</SchemaLocation>
-        </Format>		
+	
     </Formats>
 
     <Transformers>

--- a/config/xoai.config
+++ b/config/xoai.config
@@ -9,18 +9,18 @@
 xoai.dir = config
 
 # Name of the site
-repository.name = XOAI at my National Network
-mail.admin = admin@mail.com
+repository.name = XOAI SciELO Network
+mail.admin = infra@scielo.org
 
 # Storage: solr | database 
 storage=solr
 
 # Base solr index
-solr.url=http://solr:8983/solr/oai
+solr.url=http://192.168.15.145:8983/solr/oai
 
 # OAI persistent identifier prefix.
 # Format - oai:PREFIX:HANDLE
-identifier.prefix = localhost
+identifier.prefix = oai:scielo:
 
 # Base url for bitstreams
 #bitstream.baseUrl = http://localhost:8080/xmlui

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -19,7 +19,6 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-
         <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}" type="text/css" />
         <link rel="stylesheet" th:href="@{/css/bootstrap-theme.min.css}" type="text/css" />
         <link rel="stylesheet" th:href="@{/css/style.css}" type="text/css" />
@@ -33,22 +32,16 @@
             <!-- Static navbar -->
             <div class="navbar navbar-default" role="navigation">
                 <div class="navbar-header">
-                    <a class="navbar-brand" href="#">XOAI OAI-PMH Data Provider - LaReferencia</a>
+                    <a class="navbar-brand" href="#">XOAI OAI-PMH Data Provider - SciELO</a>
                 </div>
                 <div class="navbar-collapse collapse">
 
                 </div><!--/.nav-collapse -->
             </div>
 
-            <div class="alert alert-danger text-center">
-                Invalid context
-            </div>
-
-
-
 			<!-- Main component for a primary marketing message or call to action -->
             <div class="row-fluid">
-                <h2>Available Contexts</h2>
+                <!-- <h2>Available Contexts</h2> -->
                 <div class="list-group xoai-contexts">
                     <div th:each="item : ${contexts}" class="list-group-item">
                         <h4 class="list-group-item-heading" th:text="${item.name}"></h4>

--- a/static/xslt/style.xsl
+++ b/static/xslt/style.xsl
@@ -34,7 +34,7 @@
                 <div class="container">
                     <div class="navbar navbar-default" role="navigation">
                         <div class="navbar-header">
-                            <a class="navbar-brand" href="#">XOAI OAI-PMH Data Provider - LAReferencia</a>
+                            <a class="navbar-brand" href="/">XOAI OAI-PMH Data Provider - SciELO</a>
                         </div>
                         <div class="navbar-collapse collapse">
                             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR adiciona o formato AGRIS para o serviço do OAI-PMH

#### Onde a revisão poderia começar?

Sugiro que seja revisado o formato agris é possível termos esse formato no link como exemplo: 

https://www.scielo.cl/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc_agris 

#### Como este poderia ser testado manualmente?

Para testas é necessário está com o serviço do OAI-PMH funcionando e acessar o seguinte formato: 

<img width="1208" alt="Screenshot 2023-08-29 at 08 32 38" src="https://github.com/scieloorg/oaipmh/assets/86991526/6abfc4d6-5e5e-4489-b53a-c54c1edd15e9">


#### Algum cenário de contexto que queira dar?

Veja mais sobre o formato AGRIS no link: http://eprints.rclis.org/15602/

### Screenshots

<img width="1035" alt="Screenshot 2023-08-29 at 08 36 25" src="https://github.com/scieloorg/oaipmh/assets/86991526/e79a337e-f5da-4dcb-ad8a-4acd0e0d0ded">


#### Quais são tickets relevantes?

Não há tíquete para essa atividade.

### Referências

Links de referência sobre o formato agris: 

http://www.eventos.bvsalud.org/agendas/isis3/public/documents/07_SciELO_annex-175416.pdf
https://www.fao.org/3/ae908e/ae908e00.htm
https://www.fao.org/3/ae908e/ae908e00.pdf
https://www.scielo.cl/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc_agris
http://eprints.rclis.org/15602/
https://www.fao.org/agris/es/publications/scielo-articles-available-agricultural-community-using-oai-pmh-agris-ap-xml-format
https://docplayer.es/6312838-Scielo-articulos-disponibles-para-la-comunidad-agraria-utilizando-oai-pmh-y-formato-agris-ap-xml.html

