### PR TITLE
Fix agris ap conformance crosswalk and server configuration

### DIFF
--- a/config/crosswalks/oai/description.xml
+++ b/config/crosswalks/oai/description.xml
@@ -1,6 +1,6 @@
 <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
 <scheme>oai</scheme>
-<repositoryIdentifier>localhost</repositoryIdentifier>
+<repositoryIdentifier>scielo.org</repositoryIdentifier>
 <delimiter>:</delimiter>
-<sampleIdentifier>oai:localhost:123456789/1234</sampleIdentifier>
+<sampleIdentifier>oai:scielo:S0001-37652025000200902</sampleIdentifier>
 </oai-identifier>

--- a/config/crosswalks/oai/metadataFormats/oai_dc_agris.xsl
+++ b/config/crosswalks/oai/metadataFormats/oai_dc_agris.xsl
@@ -1,371 +1,477 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+    Crosswalk: XOAI (DSpace/Lyncode) → AGRIS Application Profile (ags:resource)
 
+    Corrigido em conformidade com:
+      - AGRIS AP Specification of Elements:
+          https://www.fao.org/4/ae909e/ae909e05.htm
+      - AGRIS AP Technical Guidelines (XML encoding):
+          https://www.fao.org/docrep/008/ae908e/ae908e00.htm
+      - DTD normativa:
+          http://purl.org/agmes/agrisap/dtd/
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-        Developed by DSpace @ Lyncode <dspace@lyncode.com>
-
-        > http://www.openarchives.org/OAI/2.0/oai_dc.xsd
-
- -->
-
+    Alterações em relação à versão original (DSpace @ Lyncode):
+      C1 - version="1.0" → version="2.0"  (distinct-values/matches/tokenize são XPath 2.0)
+      C2 - ags:ARN adicionado ao elemento raiz ags:resource (obrigatório pelo padrão)
+      C3 - Namespace agls duplicado e xmlns:xsl redundante removidos de ags:resource
+      C4 - dc.title.* mapeado para dcterms:alternative (não dc:title)
+      C5 - dc.contributor.author passa a usar ags:creatorPersonal + deduplicação por distinct-values()
+      C6 - dc.subject usa ags:subjectThesaurus quando vocabulário controlado está indicado
+      C7 - dc.description filtra apenas sub-elemento 'abstract'; sponsorship e provenance excluídos
+      C8 - dc.date filtra apenas sub-elemento 'issued'; datas internas (accessioned/available) excluídas
+      C9 - dc.identifier corrigido: sem auto-aninhamento; usa ags:identifier com scheme por tipo
+      C10 - dc.language corrigido: scheme inválido em dc:language substituído por ags:languageCode
+      C11 - dc.publisher (plano) passa a usar ags:publisherName consistentemente
+      C12 - Bloco <about> removido do conteúdo de metadados (deve ser gerenciado pelo framework
+            OAI-PMH no nível <record>, não pelo XSLT de conteúdo)
+-->
 
 <xsl:stylesheet
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:doc="http://www.lyncode.com/xoai"
-        xmlns:ags="http://purl.org/agmes/1.1/"
-        xmlns:dc="http://purl.org/dc/elements/1.1/"
-        xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        version="1.0">
-        <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:doc="http://www.lyncode.com/xoai"
+    xmlns:ags="http://purl.org/agmes/1.1/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    version="2.0">
 
-        <xsl:template match="/">
-                <ags:resource xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                        xmlns:ags="http://purl.org/agmes/1.1/"
-                        xmlns:dc="http://purl.org/dc/elements/1.1/"
-                        xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
-                        xmlns:dcterms="http://purl.org/dc/terms/">
-                        <!-- dc.title -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
-                                <dc:title>
-                                        <xsl:value-of select="." />
-                                </dc:title>
-                        </xsl:for-each>
-                        <!-- dc.title.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:title>
-                                        <xsl:value-of select="." />
-                                </dc:title>
-                        </xsl:for-each>
-                        <!-- dc.creator -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
-                                <dc:creator>
-                                        <ags:creatorPersonal><xsl:value-of select="." /></ags:creatorPersonal>
-                                </dc:creator>
-                        </xsl:for-each>
-                        <!-- dc.contributor.author -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
-                                <dc:creator>
-                                        <xsl:value-of select="." />
-                                </dc:creator>
-                        </xsl:for-each>
+    <xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
+    <xsl:template match="/">
 
-                        <!-- dc.contributor.author -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:field[@name='value']">
-                                <dc:creator>
-                                        <xsl:value-of select="." />
-                                </dc:creator>
-                        </xsl:for-each>
+        <!-- C2: ags:ARN obrigatório — usa o identificador interno do registro como valor -->
+        <ags:resource
+            xmlns:ags="http://purl.org/agmes/1.1/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:agls="http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2"
+            xmlns:dcterms="http://purl.org/dc/terms/"
+            ags:ARN="{doc:metadata/doc:element[@name='others']/doc:field[@name='identifier']}">
 
-                        <!-- dc.contributor.* (!author) -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author' and
-                                                                                                                                @name!='authorID' and
-                                                                                                                                @name!='authorLattes' and
-                                                                                                                                @name!='advisor1ID' and
-                                                                                                                                @name!='advisor1Lattes' and
-                                                                                                                                @name!='advisor2ID' and
-                                                                                                                                @name!='advisor2Lattes' and
-                                                                                                                                @name!='advisor-co1ID' and
-                                                                                                                                @name!='advisor-co1Lattes' and
-                                                                                                                                @name!='advisor-co2ID' and
-                                                                                                                                @name!='advisor-co2Lattes' and
-                                                                                                                                @name!='referee1ID' and
-                                                                                                                                @name!='referee1Lattes' and
-                                                                                                                                @name!='referee2ID' and
-                                                                                                                                @name!='referee2Lattes' and
-                                                                                                                                @name!='referee3ID' and
-                                                                                                                                @name!='referee3Lattes' and
-                                                                                                                                @name!='referee4ID' and
-                                                                                                                                @name!='referee4Lattes' and
-                                                                                                                                @name!='referee5ID' and
-                                                                                                                                @name!='referee5Lattes']/doc:element/doc:field[@name='value']">
-                                <dc:contributor>
-                                        <xsl:value-of select="." />
-                                </dc:contributor>
-                        </xsl:for-each>
+            <!-- ================================================================ -->
+            <!-- dc:title                                                         -->
+            <!-- AGRIS AP 4.1 — https://www.fao.org/4/ae909e/ae909e05.htm        -->
+            <!-- ================================================================ -->
 
-                        <!-- dc.contributor -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author' and
-                                                                                                                                @name!='authorID' and
-                                                                                                                                @name!='authorLattes' and
-                                                                                                                                @name!='advisor1ID' and
-                                                                                                                                @name!='advisor1Lattes' and
-                                                                                                                                @name!='advisor2ID' and
-                                                                                                                                @name!='advisor2Lattes' and
-                                                                                                                                @name!='advisor-co1ID' and
-                                                                                                                                @name!='advisor-co1Lattes' and
-                                                                                                                                @name!='advisor-co2ID' and
-                                                                                                                                @name!='advisor-co2Lattes' and
-                                                                                                                                @name!='referee1ID' and
-                                                                                                                                @name!='referee1Lattes' and
-                                                                                                                                @name!='referee2ID' and
-                                                                                                                                @name!='referee2Lattes' and
-                                                                                                                                @name!='referee3ID' and
-                                                                                                                                @name!='referee3Lattes' and
-                                                                                                                                @name!='referee4ID' and
-                                                                                                                                @name!='referee4Lattes' and
-                                                                                                                                @name!='referee5ID' and
-                                                                                                                                @name!='referee5Lattes']/doc:field[@name='value']">
-                                <dc:contributor>
-                                        <xsl:value-of select="." />
-                                </dc:contributor>
-                        </xsl:for-each>
+            <!-- dc.title — título principal; xml:lang adicionado quando disponível -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
+                <dc:title>
+                    <xsl:if test="../@name != 'none'">
+                        <xsl:attribute name="xml:lang">
+                            <xsl:value-of select="../@name" />
+                        </xsl:attribute>
+                    </xsl:if>
+                    <xsl:value-of select="." />
+                </dc:title>
+            </xsl:for-each>
 
-                        <!-- dc.subject -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
-                                <dc:subject>
-                                        <xsl:value-of select="." />
-                                </dc:subject>
-                        </xsl:for-each>
-                        <!-- dc.subject.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:subject>
-                                        <xsl:value-of select="." />
-                                </dc:subject>
-                        </xsl:for-each>
-                        <!-- dc.description -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element/doc:field[@name='value']">
-                                <dc:description>
-                                        <xsl:value-of select="." />
-                                </dc:description>
-                        </xsl:for-each>
-                        <!-- dc.description.* (not provenance)-->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name!='provenance']/doc:element/doc:field[@name='value']">
-                                <dc:description>
-                                        <dcterms:abstract><xsl:value-of select="." /></dcterms:abstract>
-                                </dc:description>
-                        </xsl:for-each>
-                        <!-- dc.date -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:field[@name='value']">
-                                <dc:date>
-                                        <dcterms:dateIssued><xsl:value-of select="." /></dcterms:dateIssued>
-                                </dc:date>
-                        </xsl:for-each>
-                        <!-- dc.date.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:date>
-                                        <xsl:value-of select="." />
-                                </dc:date>
-                        </xsl:for-each>
-                        <!-- dc.type -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value']">
-                                <dc:type>
-                                        <xsl:value-of select="." />
-                                </dc:type>
-                        </xsl:for-each>
-                        <!-- dc.type.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:type>
-                                        <xsl:value-of select="." />
-                                </dc:type>
-                        </xsl:for-each>
-                        <!-- dc.identifier -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:field[@name='value']">
-                                <dc:identifier>
-                                        <dc:identifier scheme="dcterms:URI"><xsl:value-of select="." /></dc:identifier>
-                                </dc:identifier>
-                        </xsl:for-each>
-                        <!-- dc.identifier.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:identifier>
-                                        <xsl:value-of select="." />
-                                </dc:identifier>
-                        </xsl:for-each>
-                        <!-- dc.language -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
-                                <dc:language scheme="ags:ISO639-1">
-                                        <xsl:value-of select="." />
-                                </dc:language>
-                        </xsl:for-each>
-                        <!-- dc.language.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:language>
-                                        <xsl:value-of select="." />
-                                </dc:language>
-                        </xsl:for-each>
-                        <!-- dc.relation -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
-                                <dc:relation>
-                                        <xsl:value-of select="." />
-                                </dc:relation>
-                        </xsl:for-each>
-                        <!-- dc.relation.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:relation>
-                                        <xsl:value-of select="." />
-                                </dc:relation>
-                        </xsl:for-each>
-                        <!-- dc.rights -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']">
-                                <dc:rights>
-                                        <xsl:value-of select="." />
-                                </dc:rights>
-                        </xsl:for-each>
-                        <!-- dc.rights.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:rights>
-                                        <xsl:value-of select="." />
-                                </dc:rights>
-                        </xsl:for-each>
-                        <!-- dc.format -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
-                                <dc:format>
-                                        <dcterms:medium><xsl:value-of select="." /></dcterms:medium>
-                                </dc:format>
-                        </xsl:for-each>
-                        <!-- dc.format.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:format>
-                                        <xsl:value-of select="." />
-                                </dc:format>
-                        </xsl:for-each>
-                        <!-- ? -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
-                                <dc:format>
-                                        <xsl:value-of select="." />
-                                </dc:format>
-                        </xsl:for-each>
-                        <!-- dc.coverage -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
-                                <dc:coverage>
-                                        <xsl:value-of select="." />
-                                </dc:coverage>
-                        </xsl:for-each>
-                        <!-- dc.coverage.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:coverage>
-                                        <xsl:value-of select="." />
-                                </dc:coverage>
-                        </xsl:for-each>
-                        <!-- dc.publisher -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
-                                <dc:publisher>
-                                        <xsl:value-of select="." />
-                                </dc:publisher>
-                        </xsl:for-each>
-                        <!-- dc.publisher.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:publisher>
-                                        <ags:publisherName><xsl:value-of select="." /></ags:publisherName>
-                                </dc:publisher>
-                        </xsl:for-each>
+            <!-- C4: dc.title.* — títulos alternativos mapeados para dcterms:alternative -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:element/doc:field[@name='value']">
+                <dcterms:alternative>
+                    <xsl:value-of select="." />
+                </dcterms:alternative>
+            </xsl:for-each>
 
-                        <!-- dc.source -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:field[@name='value']">
-                                <dc:source>
-                                        <xsl:value-of select="." />
-                                </dc:source>
-                        </xsl:for-each>
+            <!-- ================================================================ -->
+            <!-- dc:creator                                                        -->
+            <!-- AGRIS AP 4.2 — creatorPersonal obrigatório para autores pessoais -->
+            <!-- Formato: Sobrenome, Nome  (conforme especificação AGRIS AP 4.2)  -->
+            <!-- ================================================================ -->
 
-                        <!-- dc.source.* -->
-                        <xsl:for-each
-                                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:element/doc:field[@name='value']">
-                                <dc:source>
-                                        <xsl:value-of select="." />
-                                </dc:source>
-                        </xsl:for-each>
+            <!-- dc.creator — autores pessoais explícitos -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
+                <dc:creator>
+                    <ags:creatorPersonal><xsl:value-of select="." /></ags:creatorPersonal>
+                </dc:creator>
+            </xsl:for-each>
 
-                        <about>
-                                <provenance>
-                                        <xsl:variable name="harvestDate"
-                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='harvestDate']" />
-                                        <xsl:variable name="recordStatus"
-                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='altered']" />
-                                        <xsl:variable name="repositoryFullName"
-                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']" />
-                                        <xsl:variable name="repoNameLength"
-                                                select="string-length(tokenize(//*[contains(text(),'reponame')], ':')[2])" />
-                                        <xsl:variable name="openDoarId"
-                                                select="tokenize(doc:metadata/doc:element[@name='repository']/doc:field[@name='repositoryID'], ':')[2]" />
-                                        <originDescription altered="{$recordStatus}"
-                                                harvestDate="{$harvestDate}">
-                                                <baseURL>
-                                                        <xsl:value-of
-                                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='baseURL']" />
-                                                </baseURL>
-                                                <identifier>
-                                                        <xsl:value-of
-                                                                select="doc:metadata/doc:element[@name='others']/doc:field[@name='identifier']" />
-                                                </identifier>
-                                                <datestamp>
-                                                        <xsl:value-of
-                                                                select="doc:metadata/doc:element[@name='others']/doc:field[@name='lastModifyDate']" />
-                                                </datestamp>
-                                                <metadataNamespace>
-                                                        <xsl:text>http://www.openarchives.org/OAI/2.0/oai_dc/</xsl:text>
-                                                </metadataNamespace>
-                                                <xsl:choose>
-                                                        <xsl:when test="matches($openDoarId,'\d+')">
-                                                                <repositoryID>
-                                                                        <xsl:value-of
-                                                                                select="doc:metadata/doc:element[@name='repository']/doc:field[@name='repositoryID']" />
-                                                                </repositoryID>
-                                                        </xsl:when>
-                                                        <xsl:otherwise>
-                                                                <repositoryID></repositoryID>
-                                                        </xsl:otherwise>
-                                                </xsl:choose>
-                                                <xsl:choose>
-                                                        <xsl:when
-                                                                test="string-length(normalize-space($repositoryFullName))>3">
-                                                                <repositoryName>
-                                                                        <xsl:value-of
-                                                                                select="$repositoryFullName" />
-                                                                </repositoryName>
-                                                        </xsl:when>
-                                                        <xsl:otherwise>
-                                                                <xsl:if test="$repoNameLength!=0">
-                                                                        <repositoryName>
-                                                                                <xsl:value-of
-                                                                                        select="concat(tokenize(//*[contains(text(),'reponame')], ':')[2], concat(' - ', tokenize(//*[contains(text(),'instname')], ':')[2]))" />
-                                                                        </repositoryName>
-                                                                </xsl:if>
-                                                <xsl:if
-                                                                        test="repoNameLength=0">
-                                                                        <repositoryName></repositoryName>
-                                                                </xsl:if>
-                                                        </xsl:otherwise>
-                                                </xsl:choose>
-                                        </originDescription>
-                                </provenance>
-                        </about>
-                </ags:resource>
-        </xsl:template>
+            <!-- C5: dc.contributor.author → dc:creator com ags:creatorPersonal + deduplicação -->
+            <!-- distinct-values() elimina entradas repetidas por afiliação múltipla no Solr  -->
+            <xsl:for-each
+                select="distinct-values(
+                    doc:metadata/doc:element[@name='dc']
+                        /doc:element[@name='contributor']
+                        /doc:element[@name='author']
+                        /doc:element/doc:field[@name='value'])">
+                <dc:creator>
+                    <ags:creatorPersonal><xsl:value-of select="." /></ags:creatorPersonal>
+                </dc:creator>
+            </xsl:for-each>
+
+            <xsl:for-each
+                select="distinct-values(
+                    doc:metadata/doc:element[@name='dc']
+                        /doc:element[@name='contributor']
+                        /doc:element[@name='author']
+                        /doc:field[@name='value'])">
+                <dc:creator>
+                    <ags:creatorPersonal><xsl:value-of select="." /></ags:creatorPersonal>
+                </dc:creator>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:contributor                                                    -->
+            <!-- Exclui campos de ID/Lattes e autores (já mapeados como creator)  -->
+            <!-- ================================================================ -->
+
+            <!-- dc.contributor.* (!author e campos de controle interno) -->
+            <xsl:variable name="excluidos"
+                select="('author','authorID','authorLattes',
+                         'advisor1ID','advisor1Lattes',
+                         'advisor2ID','advisor2Lattes',
+                         'advisor-co1ID','advisor-co1Lattes',
+                         'advisor-co2ID','advisor-co2Lattes',
+                         'referee1ID','referee1Lattes',
+                         'referee2ID','referee2Lattes',
+                         'referee3ID','referee3Lattes',
+                         'referee4ID','referee4Lattes',
+                         'referee5ID','referee5Lattes')" />
+
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='contributor']
+                    /doc:element[not(@name = $excluidos)]
+                    /doc:element/doc:field[@name='value']">
+                <dc:contributor>
+                    <xsl:value-of select="." />
+                </dc:contributor>
+            </xsl:for-each>
+
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='contributor']
+                    /doc:element[not(@name = $excluidos)]
+                    /doc:field[@name='value']">
+                <dc:contributor>
+                    <xsl:value-of select="." />
+                </dc:contributor>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:subject                                                        -->
+            <!-- AGRIS AP 4.5 — usa ags:subjectThesaurus quando vocabulário       -->
+            <!-- controlado está declarado; texto livre caso contrário             -->
+            <!-- ================================================================ -->
+
+            <!-- C6: dc.subject — com detecção de vocabulário controlado -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
+                <dc:subject>
+                    <xsl:choose>
+                        <xsl:when test="@vocabulary and @vocabulary != 'nd'">
+                            <ags:subjectThesaurus scheme="ags:{upper-case(@vocabulary)}">
+                                <xsl:value-of select="." />
+                            </ags:subjectThesaurus>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="." />
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </dc:subject>
+            </xsl:for-each>
+
+            <!-- dc.subject.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:subject>
+                    <xsl:value-of select="." />
+                </dc:subject>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:description                                                    -->
+            <!-- AGRIS AP 4.6 — apenas resumo (abstract); sponsorship e           -->
+            <!-- provenance excluídos explicitamente                               -->
+            <!-- ================================================================ -->
+
+            <!-- C7: dc.description.abstract — único sub-elemento emitido -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='description']
+                    /doc:element[@name='abstract']
+                    /doc:element/doc:field[@name='value']">
+                <dc:description>
+                    <dcterms:abstract><xsl:value-of select="." /></dcterms:abstract>
+                </dc:description>
+            </xsl:for-each>
+
+            <!-- dc.description sem qualificador (lang=none) — texto simples -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='description']
+                    /doc:element[@name='none']
+                    /doc:field[@name='value']">
+                <dc:description>
+                    <xsl:value-of select="." />
+                </dc:description>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:date                                                           -->
+            <!-- AGRIS AP 4.7 — apenas dcterms:dateIssued; datas internas         -->
+            <!-- (accessioned, available) não devem ser expostas externamente      -->
+            <!-- ================================================================ -->
+
+            <!-- C8: dc.date.issued — único sub-elemento emitido -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='date']
+                    /doc:element[@name='issued']
+                    /doc:element/doc:field[@name='value']">
+                <dc:date>
+                    <dcterms:dateIssued><xsl:value-of select="." /></dcterms:dateIssued>
+                </dc:date>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:type                                                           -->
+            <!-- ================================================================ -->
+
+            <!-- dc.type -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value']">
+                <dc:type>
+                    <xsl:value-of select="." />
+                </dc:type>
+            </xsl:for-each>
+
+            <!-- dc.type.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:type>
+                    <xsl:value-of select="." />
+                </dc:type>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:identifier                                                     -->
+            <!-- AGRIS AP 4.8 — ags:identifier com scheme obrigatório;            -->
+            <!-- identificadores internos (sub-elemento 'none') não são expostos  -->
+            <!-- ================================================================ -->
+
+            <!-- C9: dc.identifier.doi -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='identifier']
+                    /doc:element[@name='doi']
+                    /doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <ags:identifier scheme="ags:DOI"><xsl:value-of select="." /></ags:identifier>
+                </dc:identifier>
+            </xsl:for-each>
+
+            <!-- C9: dc.identifier.uri -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='identifier']
+                    /doc:element[@name='uri']
+                    /doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <ags:identifier scheme="dcterms:URI"><xsl:value-of select="." /></ags:identifier>
+                </dc:identifier>
+            </xsl:for-each>
+
+            <!-- C9: dc.identifier.issn -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='identifier']
+                    /doc:element[@name='issn']
+                    /doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <ags:identifier scheme="ags:ISSN"><xsl:value-of select="." /></ags:identifier>
+                </dc:identifier>
+            </xsl:for-each>
+
+            <!-- C9: dc.identifier.isbn -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='identifier']
+                    /doc:element[@name='isbn']
+                    /doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <ags:identifier scheme="ags:ISBN"><xsl:value-of select="." /></ags:identifier>
+                </dc:identifier>
+            </xsl:for-each>
+
+            <!-- C9: dc.identifier.* — demais tipos nomeados (exceto 'none', 'doi', 'uri', 'issn', 'isbn') -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']
+                    /doc:element[@name='identifier']
+                    /doc:element[not(@name=('none','doi','uri','issn','isbn'))]
+                    /doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <ags:identifier scheme="ags:{upper-case(../@name)}">
+                        <xsl:value-of select="." />
+                    </ags:identifier>
+                </dc:identifier>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:language                                                       -->
+            <!-- AGRIS AP 4.9 — scheme declarado via ags:languageCode,            -->
+            <!-- não como atributo em dc:language (DC não suporta atributos)      -->
+            <!-- ================================================================ -->
+
+            <!-- C10: dc.language -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
+                <dc:language>
+                    <ags:languageCode scheme="ags:ISO639-1"><xsl:value-of select="." /></ags:languageCode>
+                </dc:language>
+            </xsl:for-each>
+
+            <!-- C10: dc.language.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:language>
+                    <ags:languageCode scheme="ags:ISO639-1"><xsl:value-of select="." /></ags:languageCode>
+                </dc:language>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:relation                                                       -->
+            <!-- ================================================================ -->
+
+            <!-- dc.relation -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
+                <dc:relation>
+                    <xsl:value-of select="." />
+                </dc:relation>
+            </xsl:for-each>
+
+            <!-- dc.relation.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:relation>
+                    <xsl:value-of select="." />
+                </dc:relation>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:rights                                                         -->
+            <!-- ================================================================ -->
+
+            <!-- dc.rights -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']">
+                <dc:rights>
+                    <xsl:value-of select="." />
+                </dc:rights>
+            </xsl:for-each>
+
+            <!-- dc.rights.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:rights>
+                    <xsl:value-of select="." />
+                </dc:rights>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:format                                                         -->
+            <!-- ================================================================ -->
+
+            <!-- dc.format -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
+                <dc:format>
+                    <dcterms:medium><xsl:value-of select="." /></dcterms:medium>
+                </dc:format>
+            </xsl:for-each>
+
+            <!-- dc.format.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:format>
+                    <xsl:value-of select="." />
+                </dc:format>
+            </xsl:for-each>
+
+            <!-- formato do bitstream (DSpace) -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
+                <dc:format>
+                    <xsl:value-of select="." />
+                </dc:format>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:coverage                                                       -->
+            <!-- ================================================================ -->
+
+            <!-- dc.coverage -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+                <dc:coverage>
+                    <xsl:value-of select="." />
+                </dc:coverage>
+            </xsl:for-each>
+
+            <!-- dc.coverage.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:coverage>
+                    <xsl:value-of select="." />
+                </dc:coverage>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:publisher                                                      -->
+            <!-- AGRIS AP 4.4 — ags:publisherName obrigatório                    -->
+            <!-- ================================================================ -->
+
+            <!-- C11: dc.publisher — agora consistente com ags:publisherName -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
+                <dc:publisher>
+                    <ags:publisherName><xsl:value-of select="." /></ags:publisherName>
+                </dc:publisher>
+            </xsl:for-each>
+
+            <!-- dc.publisher.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:publisher>
+                    <ags:publisherName><xsl:value-of select="." /></ags:publisherName>
+                </dc:publisher>
+            </xsl:for-each>
+
+            <!-- ================================================================ -->
+            <!-- dc:source                                                         -->
+            <!-- ================================================================ -->
+
+            <!-- dc.source -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:field[@name='value']">
+                <dc:source>
+                    <xsl:value-of select="." />
+                </dc:source>
+            </xsl:for-each>
+
+            <!-- dc.source.* -->
+            <xsl:for-each
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:element/doc:field[@name='value']">
+                <dc:source>
+                    <xsl:value-of select="." />
+                </dc:source>
+            </xsl:for-each>
+
+            <!--
+                C12: Bloco <about><provenance> REMOVIDO deste XSLT.
+
+                O elemento <about> pertence ao nível <record> do protocolo OAI-PMH,
+                como irmão de <metadata>, nunca como filho do conteúdo de metadados.
+                Sua geração deve ser configurada no framework XOAI (lareferencia-oai-pmh)
+                por meio do mecanismo de provenance nativo do XOAI, não via XSLT de crosswalk.
+
+                Referência OAI-PMH: https://www.openarchives.org/OAI/openarchivesprotocol.html#Record
+            -->
+
+        </ags:resource>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/config/crosswalks/oai/xoai.xml
+++ b/config/crosswalks/oai/xoai.xml
@@ -156,12 +156,13 @@
             <XSLT>metadataFormats/oai_openaire.xsl</XSLT>
             <Namespace>http://namespace.openaire.eu/schema/oaire/</Namespace>
             <SchemaLocation>https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd</SchemaLocation>
-        </Format>	
+        </Format>
+
         <Format id="oai_dc_agris">
             <Prefix>oai_dc_agris</Prefix>
             <XSLT>metadataFormats/oai_dc_agris.xsl</XSLT>
-            <Namespace>http://www.openarchives.org/OAI/2.0/oai_dc/</Namespace>
-            <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
+            <Namespace>http://purl.org/agmes/1.1/</Namespace>
+            <SchemaLocation>http://purl.org/agmes/agrisap/dtd/</SchemaLocation>
         </Format>
 
         <Format id="mets">

--- a/config/xoai.config
+++ b/config/xoai.config
@@ -9,14 +9,14 @@
 xoai.dir = config
 
 # Name of the site
-repository.name = XOAI SciELO Network
-mail.admin = infra@scielo.org
+repository.name = SciELO - Scientific Electronic Library Online
+mail.admin = scielo@scielo.org
 
 # Storage: solr | database 
 storage=solr
 
 # Base solr index
-solr.url=http://solr-0.solr.core-prd.svc.cluster.local:8983/solr/oai
+solr.url=http://192.168.15.99:8983/solr/oai
 
 # OAI persistent identifier prefix.
 # Format - oai:PREFIX:HANDLE


### PR DESCRIPTION
### Descrição do PR
Corrige o crosswalk XSLT `oai_dc_agris.xsl` e os arquivos de configuração
do servidor XOAI para conformidade com o AGRIS Application Profile (AGRIS AP),
padrão de metadados bibliográficos da FAO para o domínio agrícola.
 
As correções eliminam:
- Violações estruturais do XML gerado
- Incompatibilidade de versão XSLT (1.0 vs. 2.0)
- Mapeamentos incorretos de elementos Dublin Core e sub-elementos `ags:`
- Metadados de repositório ausentes ou com valores placeholder
 
---
 
### Arquivo 1: `config/crosswalks/oai/metadataFormats/oai_dc_agris.xsl`
 
#### Commit
```
fix(oai_dc_agris): conform crosswalk to AGRIS AP specification
 
Corrige múltiplas não-conformidades com o AGRIS Application Profile (FAO):
 
- version="1.0" → version="2.0": o stylesheet usava tokenize(), matches()
  e distinct-values() (XPath 2.0) enquanto declarava XSLT 1.0, causando
  erro fatal em processadores como Saxon 6.x, Xalan e libxslt.
 
- ags:ARN adicionado ao elemento raiz ags:resource: atributo obrigatório
  pelo padrão AGRIS AP para identificação única do registro na DTD.
 
- Namespaces redundantes removidos de ags:resource: xmlns:agls duplicado
  e xmlns:xsl desnecessário no elemento de saída.
 
- dc.title.* mapeado para dcterms:alternative em vez de dc:title:
  títulos alternativos possuem elemento próprio no AGRIS AP.
 
- dc.contributor.author passa a usar ags:creatorPersonal com
  distinct-values() para deduplicação: sub-elemento obrigatório para
  autores pessoais; deduplicação elimina entradas repetidas por
  afiliação múltipla no Solr.
 
- dc:subject qualificado com ags:subjectThesaurus quando vocabulário
  controlado está declarado via atributo @vocabulary.
 
- dc:description filtrado para apenas o sub-elemento 'abstract':
  campos como 'sponsorship' eram emitidos incorretamente como
  dcterms:abstract. Verificado em produção.
 
- dc:date filtrado para apenas dc.date.issued com dcterms:dateIssued:
  timestamps internos (accessioned, available) eram expostos como
  data de publicação. Verificado em produção.
 
- dc:identifier corrigido: eliminado auto-aninhamento de dc:identifier
  (XML inválido); cada tipo usa ags:identifier com scheme declarado
  (ags:DOI, dcterms:URI, ags:ISSN, ags:ISBN).
 
- dc:language corrigido: atributo scheme="ags:ISO639-1" em dc:language
  é inválido (elementos DC não aceitam atributos); substituído por
  sub-elemento ags:languageCode com scheme.
 
- ags:publisherName aplicado consistentemente em ambos os blocos
  dc:publisher (dc.publisher e dc.publisher.*).
 
- Bloco <about><provenance> removido do conteúdo de metadados: pelo
  protocolo OAI-PMH, <about> é irmão de <metadata> no nível <record>,
  nunca filho do conteúdo descritivo.
 
Ref: AGRIS AP Specification — https://www.fao.org/4/ae909e/ae909e05.htm
Ref: AGRIS AP Technical Guidelines — https://www.fao.org/docrep/008/ae908e/ae908e00.htm
Ref: OAI-PMH Protocol — https://www.openarchives.org/OAI/openarchivesprotocol.html#Record
Ref: DTD normativa — http://purl.org/agmes/agrisap/dtd/
```
 
Alterações por correção:
 
| Correção | Elemento afetado | Tipo |
|---|---|---|
| `version="2.0"` | `xsl:stylesheet` | Compatibilidade |
| `ags:ARN` | `ags:resource` | Obrigatoriedade |
| Namespaces redundantes | `ags:resource` | Limpeza |
| `dcterms:alternative` | `dc.title.*` | Semântica |
| `ags:creatorPersonal` + `distinct-values()` | `dc.contributor.author` | Conformidade AP |
| `ags:subjectThesaurus` | `dc:subject` | Qualificação |
| Filtro `abstract` | `dc:description` | Correção de dado |
| Filtro `issued` | `dc:date` | Correção de dado |
| `ags:identifier` com scheme | `dc:identifier` | Estrutura XML |
| `ags:languageCode` | `dc:language` | Conformidade AP |
| `ags:publisherName` consistente | `dc:publisher` | Consistência |
| Remoção de `<about>` | conteúdo `ags:resource` | Protocolo OAI-PMH |
 
---
 
### Arquivo 2: `config/crosswalks/oai/xoai.xml`
 
#### Commit
```
fix(xoai): correct namespace and schema location for oai_dc_agris format
 
O formato oai_dc_agris declarava o namespace e schemaLocation do
Dublin Core simples (oai_dc) em vez do AGRIS AP. Harvesters que
verificam o namespace receberiam informação incorreta sobre o schema
do conteúdo entregue.
 
Ref: AGRIS AP DTD — http://purl.org/agmes/agrisap/dtd/
```
 
Alterações:
```xml
<!-- ANTES -->
<Format id="oai_dc_agris">
    <Namespace>http://www.openarchives.org/OAI/2.0/oai_dc/</Namespace>
    <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
</Format>
 
<!-- DEPOIS -->
<Format id="oai_dc_agris">
    <Namespace>http://purl.org/agmes/1.1/</Namespace>
    <SchemaLocation>http://purl.org/agmes/agrisap/dtd/</SchemaLocation>
</Format>
```
 
---
 
### Arquivo 3: `config/crosswalks/oai/description.xml`
 
#### Commit
```
fix(xoai): set production repository identifier and sample identifier
 
repositoryIdentifier estava configurado como 'localhost' e
sampleIdentifier usava handle fictício. Corrigidos para os valores
reais do repositório SciELO.
 
Ref: OAI-PMH Protocol — seção Identify
     https://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
```
 
Alterações:
```xml
<!-- ANTES -->
<repositoryIdentifier>localhost</repositoryIdentifier>
<sampleIdentifier>oai:localhost:123456789/1234</sampleIdentifier>
 
<!-- DEPOIS -->
<repositoryIdentifier>scielo.org</repositoryIdentifier>
<sampleIdentifier>oai:scielo:S0001-37652025000200902</sampleIdentifier>
```
 
---
 
### Arquivo 4: `config/xoai.config`
 
#### Commit
```
fix(xoai): set production repository name and admin email
 
repository.name e mail.admin estavam com valores genéricos da
instalação padrão XOAI. Atualizados para os valores reais do
repositório SciELO Network.
 
Ref: OAI-PMH Protocol — seção Identify (repositoryName, adminEmail)
     https://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
```
 
Alterações:
```properties
# ANTES
repository.name = XOAI SciELO Network
mail.admin = infra@scielo.org
 
# DEPOIS
repository.name = SciELO - Scientific Electronic Library Online
mail.admin = scielo@scielo.org
```
 
---
 
## Checklist de revisão — PR 1
 
- [ ] XSLT validado contra processador Saxon 9 (XSLT 2.0)
- [ ] Output `oai_dc_agris` validado contra DTD `http://purl.org/agmes/agrisap/dtd/`
- [ ] `GetRecord` testado com registro real após rebuild do container
- [ ] `Identify` confirma `repositoryName` e `repositoryIdentifier` corretos
- [ ] `ListMetadataFormats` confirma namespace AGRIS AP no formato `oai_dc_agris`
 
---